### PR TITLE
xlsx2md のヘッダーに GitHub アイコンリンクを追加し、アイコン単体表示に対応

### DIFF
--- a/lht-cmn/js/components.js
+++ b/lht-cmn/js/components.js
@@ -1524,10 +1524,13 @@ class LhtPageHero extends HTMLElement {
       titleMain.appendChild(help);
     }
 
-    if (actionHref && actionLabel) {
+    if (actionHref && (actionLabel || actionIconId)) {
       const actionLink = document.createElement("a");
       actionLink.href = actionHref;
       actionLink.className = "ms-hero-link";
+      if (!actionLabel) {
+        actionLink.classList.add("ms-hero-link--icon-only");
+      }
       actionLink.target = "_blank";
       actionLink.rel = "noopener noreferrer";
       if (actionAriaLabel) {
@@ -1545,9 +1548,11 @@ class LhtPageHero extends HTMLElement {
         iconSvg.appendChild(useNode);
         actionLink.appendChild(iconSvg);
       }
-      const labelNode = document.createElement("span");
-      labelNode.textContent = actionLabel;
-      actionLink.appendChild(labelNode);
+      if (actionLabel) {
+        const labelNode = document.createElement("span");
+        labelNode.textContent = actionLabel;
+        actionLink.appendChild(labelNode);
+      }
       titleMain.appendChild(actionLink);
     }
 

--- a/src/xlsx2md/css/app.css
+++ b/src/xlsx2md/css/app.css
@@ -12,8 +12,46 @@
   margin: 0 auto;
 }
 
+.md-icons {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
 .md-surface-card {
   padding: 28px;
+}
+
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #52606d;
+  text-decoration: none;
+  line-height: 1;
+  transition:
+    transform 0.16s ease,
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.ms-hero-link:hover,
+.ms-hero-link:focus-visible {
+  transform: translateY(-1px);
+  color: #102a43;
+  opacity: 1;
+}
+
+.ms-hero-link--icon-only {
+  padding: 0.1rem;
+  opacity: 0.78;
+}
+
+.ms-btn-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
 }
 
 .md-card {

--- a/xlsx2md-src.html
+++ b/xlsx2md-src.html
@@ -25,6 +25,11 @@ limitations under the License.
   <script src="lht-cmn/js/components.js" defer></script>
 </head>
 <body class="md-page">
+  <svg width="0" height="0" aria-hidden="true" focusable="false" class="md-icons">
+    <symbol id="md-icon-github" viewBox="0 0 16 16">
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+    </symbol>
+  </svg>
   <main class="md-shell">
     <section class="md-card md-surface-card">
       <lht-page-hero
@@ -33,6 +38,9 @@ limitations under the License.
         icon="📘"
         help-label="xlsx2md の説明"
         help-wide
+        action-href="https://github.com/igapyon/xlsx2md"
+        action-aria-label="Open xlsx2md repository"
+        action-icon-id="md-icon-github"
         menu-home-href="./index.html"
         menu-home-label="トップへ戻る">
         `.xlsx` ファイルをローカルで解析し、地の文抽出・表検出・結合セル補完を行ったうえで Markdown を生成します。

--- a/xlsx2md.html
+++ b/xlsx2md.html
@@ -1088,8 +1088,46 @@ lht-index-card-link {
   margin: 0 auto;
 }
 
+.md-icons {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
 .md-surface-card {
   padding: 28px;
+}
+
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #52606d;
+  text-decoration: none;
+  line-height: 1;
+  transition:
+    transform 0.16s ease,
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.ms-hero-link:hover,
+.ms-hero-link:focus-visible {
+  transform: translateY(-1px);
+  color: #102a43;
+  opacity: 1;
+}
+
+.ms-hero-link--icon-only {
+  padding: 0.1rem;
+  opacity: 0.78;
+}
+
+.ms-btn-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
 }
 
 .md-card {
@@ -1451,6 +1489,11 @@ lht-preview-output {
   </style>
 </head>
 <body class="md-page">
+  <svg width="0" height="0" aria-hidden="true" focusable="false" class="md-icons">
+    <symbol id="md-icon-github" viewBox="0 0 16 16">
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+    </symbol>
+  </svg>
   <main class="md-shell">
     <section class="md-card md-surface-card">
       <lht-page-hero
@@ -1459,6 +1502,9 @@ lht-preview-output {
         icon="📘"
         help-label="xlsx2md の説明"
         help-wide
+        action-href="https://github.com/igapyon/xlsx2md"
+        action-aria-label="Open xlsx2md repository"
+        action-icon-id="md-icon-github"
         menu-home-href="./index.html"
         menu-home-label="トップへ戻る">
         `.xlsx` ファイルをローカルで解析し、地の文抽出・表検出・結合セル補完を行ったうえで Markdown を生成します。
@@ -3572,10 +3618,13 @@ class LhtPageHero extends HTMLElement {
       titleMain.appendChild(help);
     }
 
-    if (actionHref && actionLabel) {
+    if (actionHref && (actionLabel || actionIconId)) {
       const actionLink = document.createElement("a");
       actionLink.href = actionHref;
       actionLink.className = "ms-hero-link";
+      if (!actionLabel) {
+        actionLink.classList.add("ms-hero-link--icon-only");
+      }
       actionLink.target = "_blank";
       actionLink.rel = "noopener noreferrer";
       if (actionAriaLabel) {
@@ -3593,9 +3642,11 @@ class LhtPageHero extends HTMLElement {
         iconSvg.appendChild(useNode);
         actionLink.appendChild(iconSvg);
       }
-      const labelNode = document.createElement("span");
-      labelNode.textContent = actionLabel;
-      actionLink.appendChild(labelNode);
+      if (actionLabel) {
+        const labelNode = document.createElement("span");
+        labelNode.textContent = actionLabel;
+        actionLink.appendChild(labelNode);
+      }
       titleMain.appendChild(actionLink);
     }
 


### PR DESCRIPTION
## 概要
`xlsx2md` のページヘッダーに GitHub へのリンクを追加します。あわせて、`lht-page-hero` がラベルなしのアイコン単体リンクを扱えるように調整します。

## 変更内容
- `xlsx2md-src.html`
  - GitHub 用の SVG symbol `md-icon-github` を追加
  - `lht-page-hero` に `action-href` / `action-aria-label` / `action-icon-id` を追加
- `lht-cmn/js/components.js`
  - `lht-page-hero` のアクションリンク生成条件を拡張し、`action-label` がなくても `action-icon-id` があれば描画できるように変更
  - ラベルなしの場合に `ms-hero-link--icon-only` を付与
  - ラベルがある場合のみテキストノードを追加するように変更
- `src/xlsx2md/css/app.css`
  - `.md-icons` を追加
  - `.ms-hero-link` / `.ms-hero-link--icon-only` / `.ms-btn-icon` を追加し、アイコン単体リンク用の見た目を定義
- `xlsx2md.html`
  - 上記変更の生成物を更新