### PR TITLE
文書を `docs/` 配下へ移動し、README と TODO を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 - `README.md`
   - 入口説明と全体像
-- `xlsx2md-spec.md`
+- `docs/xlsx2md-spec.md`
   - 人間が意図と設計方針を理解するための上位仕様
-- `xlsx2md-impl-spec.md`
+- `docs/xlsx2md-impl-spec.md`
   - 現行実装の詳細仕様と再実装・保守のための文書
-- `xlsx-formula-subset.md`
+- `docs/xlsx-formula-subset.md`
   - 数式対応範囲の補助文書
 
 ## 現在の状態
@@ -43,7 +43,7 @@
 
 ## 方針
 
-- 配置は `docs/xlsx2md/` とし、既存の `docs/text/` には入れない
+- 文書は `docs/` 配下に配置し、既存の `docs/text/` には入れない
 - 入出力はブラウザ内で完結し、サーバ送信を前提にしない
 - 最初の用途は「Excel 設計書を Markdown へ変換する」に置く
 - 配布形態は Single-file Web App とする
@@ -185,11 +185,13 @@ both: 2024/3/17 [raw=45368]
 ## 現在の構成イメージ
 
 ```text
-docs/xlsx2md/
+.
 ├── README.md
-├── xlsx2md-spec.md
-├── xlsx2md-impl-spec.md
-├── xlsx-formula-subset.md
+├── docs/
+│   ├── local-data-review.md
+│   ├── xlsx2md-spec.md
+│   ├── xlsx2md-impl-spec.md
+│   └── xlsx-formula-subset.md
 ├── xlsx2md-src.html
 ├── xlsx2md.html
 ├── references/
@@ -228,17 +230,19 @@ docs/xlsx2md/
     └── ...
 ```
 
-上位仕様と設計方針は [xlsx2md-spec.md](./xlsx2md-spec.md) を参照してください。
+上位仕様と設計方針は [docs/xlsx2md-spec.md](./docs/xlsx2md-spec.md) を参照してください。
 
-現行実装に即した詳細仕様は [xlsx2md-impl-spec.md](./xlsx2md-impl-spec.md) を参照してください。
+現行実装に即した詳細仕様は [docs/xlsx2md-impl-spec.md](./docs/xlsx2md-impl-spec.md) を参照してください。
 
-Excel 数式サブセットの設計メモは [xlsx-formula-subset.md](./xlsx-formula-subset.md) を参照してください。
+Excel 数式サブセットの設計メモは [docs/xlsx-formula-subset.md](./docs/xlsx-formula-subset.md) を参照してください。
+
+実データ観点の確認メモは [docs/local-data-review.md](./docs/local-data-review.md) を参照してください。
 
 fixture 用 Excel ブックの作成メモは [tests/fixtures/README.md](./tests/fixtures/README.md) を参照してください。
 
-git に入れない実データや一時検証用の `.xlsx` は `docs/xlsx2md/local-data/` に配置します。このディレクトリは `.gitignore` 対象です。
+git に入れない実データや一時検証用の `.xlsx` は `local-data/` に配置します。このディレクトリは `.gitignore` 対象です。
 
-`docs/xlsx2md/local-data/` で使う一部サンプルの取得元メモ:
+`local-data/` で使う一部サンプルの取得元メモ:
 
 - Microsoft Create planner / tracker templates: <https://excel.cloud.microsoft/create/ja/planner-tracker-templates/>
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,81 @@
+# TODO xlsx2md
+
+## 実装タスク
+
+- fixture 用 Excel ブックを追加する
+  - `tests/fixtures/formula/formula-spill-sample01.xlsx`
+- formula 次段タスク
+  - `scripts/observe-xlsx2md-formulas.mjs` による観測を継続し、AST evaluator 側へ寄せる関数群を整理する
+  - 優先順は `cached value -> AST evaluator -> 既存 resolver -> fallback_formula` で固定
+  - 既存の文字列ベース evaluator は互換 fallback として維持しつつ、AST evaluator 側へ段階移行する
+  - 既存 resolver は現時点では安全装置として必要であり、短期的には削除しない
+  - 中長期的には、実データ観測を踏まえて担当範囲を縮小し、後方互換 fallback へ寄せる
+  - 次候補:
+    - `XLOOKUP` の binary search `search_mode=2/-2` の境界条件を必要に応じて詰める
+    - 実データ頻出関数を AST evaluator 側へさらに寄せる
+- `セクション分割ブロック` の実装導入順を決める
+- UI の `formulaDiagnostics` / `tableScores` 表示を見直す
+
+## 未対応事項
+
+- 数式未対応の整理
+  - `space intersection` の完全対応
+  - 配列定数の完全対応
+  - dynamic array / spill の完全対応
+  - `LAMBDA / LET / MAP / REDUCE / SCAN`
+  - 完全な `R1C1` 文法
+  - Excel の future function 全般
+  - `NOW` など volatile 関数の完全再計算
+- レイアウト未対応の整理
+  - `セクション分割ブロック` の導入
+  - `カレンダー / ボード / ダッシュボード系` シートの専用扱い
+  - レイアウト中心シートの完全再現は対象外であり、`セクション / 表 / リスト / 画像` 分解で扱う
+  - `イベント プランナー` のようなフォーム風罫線領域は、現時点では保守的に扱う
+  - DrawingML の図形 (`xdr:sp` / `xdr:cxnSp` など) は、現時点では安全に無視またはメタデータ抽出に留める
+  - `DrawingML -> SVG` は将来候補
+  - グラフは当面、意味情報のテキスト化で固定し、`Chart -> SVG` は保留とする
+  - SmartArt は現時点では fallback とし、意味解釈や SVG 化の対象外とする
+
+## 方針未確定
+
+- `XLOOKUP` 近似一致や binary search を未ソート範囲でどう扱うか
+- `ROW / COLUMN` の文脈なし引数なし形をどう扱うか
+- 配列定数をどこまで Excel 互換で広げるか
+- `A1#` のような spill 演算子を、runtime でどこまで実解決するか
+- `f@ref` を spill と array formula でどう見分けるか
+- `TODAY / NOW` を cached value 専用に留めるか
+- `existing resolver` から AST evaluator へ、どこまで段階移行したら縮小判断するか
+
+## レイアウト系の整理
+
+- `local-data` の実データ差分レビュー継続
+  - 重点対象は `docs/local-data-review.md` を参照
+  - 優先順:
+    - `TFc2b640.../イベント プランナー` の多画像・多結合差分確認
+    - `TF97739.../月間プランナー` の merge 多用差分確認
+  - 人手確認があると助かるもの:
+    - 代表シートの Excel スクリーンショット
+    - 条件付き書式やアイコン列の意味説明
+- レイアウト中心シート方針の維持と具体化
+  - 見た目再現ではなく、`セクション / 表 / リスト / 画像` への分解を優先する
+- `セクション分割ブロック` 導入検討
+  - 対象候補: 入力パネル、概要カード、見出し付きの広い merge 領域
+- `カレンダー / ボード / ダッシュボード系` シートの別カテゴリ化検討
+  - 対象候補: `TF97739.../月間プランナー`
+  - 対象候補: `TFc2b640.../イベント プランナー`
+  - 対象候補: `TF0ffdef.../老後資金プランナー`
+
+## 進捗メモ
+
+- fixture ベースの実ファイル調整は一段落
+- formula Step 2 の最小 parser 土台は追加済み
+- formula Step 3 の最小 evaluator 土台は追加済み
+- `core.ts` に no-op の `extractSectionBlocks(...)` は追加済み
+
+## 参照
+
+- 正本: `docs/TODO.md`
+- 関連仕様:
+  - `docs/xlsx2md-spec.md`
+  - `docs/xlsx2md-impl-spec.md`
+  - `docs/xlsx-formula-subset.md`

--- a/docs/local-data-review.md
+++ b/docs/local-data-review.md
@@ -1,10 +1,10 @@
 # xlsx2md local-data review
 
-`docs/xlsx2md/local-data/` に置いた実データについて、`xlsx2md` の重点確認対象を整理するメモ。
+`local-data/` に置いた実データについて、`xlsx2md` の重点確認対象を整理するメモ。
 
 関連文書:
 
-- 概要と使い方: [README.md](./README.md)
+- 概要と使い方: [README.md](../README.md)
 - 上位仕様と設計方針: [xlsx2md-spec.md](./xlsx2md-spec.md)
 - 現行実装の詳細仕様: [xlsx2md-impl-spec.md](./xlsx2md-impl-spec.md)
 - 数式サブセットの検討メモ: [xlsx-formula-subset.md](./xlsx-formula-subset.md)

--- a/docs/xlsx-formula-subset.md
+++ b/docs/xlsx-formula-subset.md
@@ -335,8 +335,8 @@ Primary
 
 現状:
 
-- `docs/xlsx2md/src/xlsx2md/ts/formula/tokenizer.ts`
-- `docs/xlsx2md/src/xlsx2md/ts/formula/parser.ts`
+- `src/xlsx2md/ts/formula/tokenizer.ts`
+- `src/xlsx2md/ts/formula/parser.ts`
 - parser で対応済み:
   - 絶対参照
     - `$A$1`
@@ -364,8 +364,8 @@ Primary
 
 現状:
 
-- `docs/xlsx2md/src/xlsx2md/ts/formula/evaluator.ts`
-- `docs/xlsx2md/src/xlsx2md/ts/core.ts` から限定的に AST フック済み
+- `src/xlsx2md/ts/formula/evaluator.ts`
+- `src/xlsx2md/ts/core.ts` から限定的に AST フック済み
 - evaluator で対応済みの主な関数:
   - 条件・論理
     - `IF`
@@ -440,7 +440,7 @@ Primary
 ### 観測状況
 
 - `scripts/observe-xlsx2md-formulas.mjs` で `local-data` を観測可能
-- 現在は parser 観点では `docs/xlsx2md/local-data/` の全対象で `ast_ng 0`
+- 現在は parser 観点では `local-data/` の全対象で `ast_ng 0`
 - 次段の焦点は parser ではなく、AST evaluator をどこまで優先し、どの関数群をさらに寄せるか
 
 ## 未決事項

--- a/docs/xlsx2md-impl-spec.md
+++ b/docs/xlsx2md-impl-spec.md
@@ -6,7 +6,7 @@
 
 主な目的は次の通りである。
 
-- `docs/xlsx2md/src/xlsx2md/ts/*.ts` の現行実装に基づく挙動を整理する
+- `src/xlsx2md/ts/*.ts` の現行実装に基づく挙動を整理する
 - `README.md`、`xlsx2md-spec.md`、`xlsx-formula-subset.md` に分散している実装前提の情報を、実装準拠の観点で補助する
 - 将来の仕様検討や実装差分確認の際に、どこが「現行挙動」で、どこが「将来構想」かを切り分けやすくする
 
@@ -18,7 +18,7 @@
 
 `xlsx2md` 関連文書の役割分担は概ね次の通りである。
 
-- [README.md](./README.md)
+- [README.md](../README.md)
   - 概要、使い方、現在の状態、既知の制約を把握するための入口文書
 - [xlsx2md-spec.md](./xlsx2md-spec.md)
   - 上位仕様、設計方針、将来構想を整理する文書
@@ -51,7 +51,7 @@
 
 本書の記述基準は次の通りである。
 
-- 現行コードの正本は `docs/xlsx2md/src/xlsx2md/ts/` 配下の TypeScript 実装とする
+- 現行コードの正本は `src/xlsx2md/ts/` 配下の TypeScript 実装とする
 - `js/` 配下および `xlsx2md.html` はビルド生成物として扱う
 - 実装と既存文書に差分がある場合、本書では現行実装を基準に記述する
 - 未対応事項や将来検討事項は、実装済み仕様と分けて記述する
@@ -413,7 +413,7 @@ Markdown 生成時のセル出力は、`outputMode` により切り替わる。
 
 ### 7.4 AST evaluator
 
-AST evaluator は、`docs/xlsx2md/src/xlsx2md/ts/formula/` 配下の tokenizer / parser / evaluator を用いた解決系である。
+AST evaluator は、`src/xlsx2md/ts/formula/` 配下の tokenizer / parser / evaluator を用いた解決系である。
 
 現行実装では、数式文字列を AST 化し、必要に応じて次のような参照解決コンテキストを与えて評価する。
 
@@ -1263,7 +1263,7 @@ ZIP の保存名には Workbook 名と、必要に応じて outputMode サフィ
 
 ### 解析本体
 
-- `docs/xlsx2md/src/xlsx2md/ts/core.ts`
+- `src/xlsx2md/ts/core.ts`
   - ZIP 展開
   - workbook / worksheet 解析
   - sharedStrings / styles / definedNames
@@ -1276,16 +1276,16 @@ ZIP の保存名には Workbook 名と、必要に応じて outputMode サフィ
 
 ### 数式サブシステム
 
-- `docs/xlsx2md/src/xlsx2md/ts/formula/tokenizer.ts`
+- `src/xlsx2md/ts/formula/tokenizer.ts`
   - 数式トークナイズ
-- `docs/xlsx2md/src/xlsx2md/ts/formula/parser.ts`
+- `src/xlsx2md/ts/formula/parser.ts`
   - AST 構築
-- `docs/xlsx2md/src/xlsx2md/ts/formula/evaluator.ts`
+- `src/xlsx2md/ts/formula/evaluator.ts`
   - AST 評価
 
 ### UI
 
-- `docs/xlsx2md/src/xlsx2md/ts/main.ts`
+- `src/xlsx2md/ts/main.ts`
   - 画面操作
   - オプション取得
   - 解析サマリー表示
@@ -1293,23 +1293,23 @@ ZIP の保存名には Workbook 名と、必要に応じて outputMode サフィ
   - 数式診断表示
   - ダウンロード / ZIP 保存
 
-- `docs/xlsx2md/src/xlsx2md/css/app.css`
+- `src/xlsx2md/css/app.css`
   - `xlsx2md` 画面固有の見た目
 
 ### テスト
 
-- `docs/xlsx2md/tests/xlsx2md-main.test.js`
+- `tests/xlsx2md-main.test.js`
   - 実ファイルベース回帰テスト
   - Workbook 解析、Markdown 生成、画像・グラフ・図形・数式まわりの確認
 
-- `docs/xlsx2md/tests/xlsx2md-formula-parser.test.js`
+- `tests/xlsx2md-formula-parser.test.js`
   - tokenizer / parser / evaluator の単体寄り確認
 
 ### 生成物
 
-- `docs/xlsx2md/src/xlsx2md/js/*.js`
+- `src/xlsx2md/js/*.js`
   - TypeScript からの生成物
-- `docs/xlsx2md/xlsx2md.html`
+- `xlsx2md.html`
   - single-file Web App の生成物
 
 本書の記述基準は TypeScript 実装であり、生成物はその反映結果として扱う。
@@ -1318,7 +1318,7 @@ ZIP の保存名には Workbook 名と、必要に応じて outputMode サフィ
 
 本章は、`impl-spec` だけで再実装可能性を上げるための補助資料である。
 
-- 正本は `docs/xlsx2md/src/xlsx2md/ts/core.ts` とする
+- 正本は `src/xlsx2md/ts/core.ts` とする
 - ここでは、再実装時に骨格となる代表的な型定義と関数断片を掲載する
 - 全量転載ではなく、章ごとの理解と再実装の足場になる範囲へ絞る
 

--- a/docs/xlsx2md-spec.md
+++ b/docs/xlsx2md-spec.md
@@ -738,22 +738,24 @@ ImageAsset
 ## 18. 技術方針
 
 - 単一 HTML で配布する
-- 実装は `docs/xlsx2md/` 配下に閉じる
+- 文書は `docs/` 配下に配置する
 - ビルド方式は既存の `*-src.html` + 単一 HTML 生成パターンを踏襲する
 - 可能な限り依存を増やさず、必要なら最小限の同梱を検討する
 - ローカルブラウザ内で完結し、サーバ送信を前提にしない
 - UI 共通部品は `lht-cmn/` を利用する
 - アプリ本体ロジックの正本ソースは `src/xlsx2md/ts/*.ts` とする
 - 配布用 JavaScript は TypeScript から生成する
-- テストは自動実行可能な形で `docs/xlsx2md/tests/` に配置する
+- テストは自動実行可能な形で `tests/` に配置する
 
 ### 18.1 想定ディレクトリ構成
 
 ```text
-docs/xlsx2md/
+.
 ├── README.md
-├── xlsx2md-spec.md
-├── xlsx2md-impl-spec.md
+├── docs/
+│   ├── xlsx2md-spec.md
+│   ├── xlsx2md-impl-spec.md
+│   └── xlsx-formula-subset.md
 ├── xlsx2md-src.html
 ├── xlsx2md.html
 ├── src/


### PR DESCRIPTION
## 概要
文書ファイルの配置を `docs/` 配下へ整理し、関連リンクと構成説明を更新します。あわせて、`xlsx2md` 用の TODO 文書を新規追加します。

## 変更内容
- `docs/TODO.md` を新規追加
  - 実装タスク
  - 未対応事項
  - 方針未確定
  - レイアウト系の整理
  - 進捗メモ
  - 参照 を整理した TODO 文書を追加
- 文書ファイルを `docs/` 配下へ移動
  - `local-data-review.md` → `docs/local-data-review.md`
  - `xlsx-formula-subset.md` → `docs/xlsx-formula-subset.md`
  - `xlsx2md-impl-spec.md` → `docs/xlsx2md-impl-spec.md`
  - `xlsx2md-spec.md` → `docs/xlsx2md-spec.md`
- `README.md` を更新
  - 文書一覧の参照先を `docs/` 配下へ変更
  - 「方針」の文言を `docs/` 配下前提へ更新
  - 構成イメージを現行のディレクトリ構成に合わせて更新
  - `local-data/` や関連文書への参照先を更新
- 移動後の各文書を更新
  - 相対リンクを新配置に合わせて修正
  - `src/`、`tests/`、`local-data/` などのパス表記を現行配置に合わせて更新
  - 文書内の構成説明を `docs/` 配下前提に更新

## 影響範囲
- `README.md`
- `docs/TODO.md`
- `docs/local-data-review.md`
- `docs/xlsx-formula-subset.md`
- `docs/xlsx2md-impl-spec.md`
- `docs/xlsx2md-spec.md`