### PR TITLE
index.html の紹介文を実装に合わせて更新し、Single-file Web App の説明を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,20 +126,17 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>xlsx2md</h1>
-    <p class="lead">
-      Excel (`.xlsx`) をローカルで読み込み、Markdown へ変換するブラウザベースのツールです。
-    </p>
 
     <section class="lang-block" aria-label="English">
       <h2>English</h2>
       <p>
-        xlsx2md is a browser-based converter that reads Excel (`.xlsx`) files locally and turns them into Markdown.
+        xlsx2md is a Single-file Web App that reads Excel (`.xlsx`) files locally and extracts narrative text, tables, and images as Markdown.
       </p>
       <ul>
         <li>Runs in the browser.</li>
         <li>Converts all sheets automatically.</li>
         <li>Supports display / raw / both output modes.</li>
-        <li>Includes analysis-oriented output such as tables, formulas, charts, and shapes.</li>
+        <li>Extracts narrative text, tables, and images as Markdown.</li>
       </ul>
       <div class="link-row">
         <a class="link-btn" href="./xlsx2md.html?v=202603190000">Open xlsx2md</a>
@@ -152,13 +149,13 @@
     <section class="lang-block" aria-label="日本語">
       <h2>日本語</h2>
       <p>
-        xlsx2md は、Excel (`.xlsx`) をローカルで読み込み、Markdown へ変換するブラウザベースのツールです。
+        xlsx2md は、Excel (`.xlsx`) をローカルで読み込み、地の文と表と画像を Markdown として抽出する Single-file Web App です。
       </p>
       <ul>
         <li>ブラウザ内で動作します。</li>
         <li>全シートを自動で変換します。</li>
         <li>`display` / `raw` / `both` の出力モードを持ちます。</li>
-        <li>表、数式、グラフ、図形などの解析結果を Markdown に出力します。</li>
+        <li>地の文と表と画像を Markdown として抽出できます。</li>
       </ul>
       <div class="link-row">
         <a class="link-btn" href="./xlsx2md.html?v=202603190000">xlsx2md を開く</a>


### PR DESCRIPTION
## 概要
`index.html` の紹介文を見直し、説明内容を現在の表現に合わせて更新しました。

## 変更内容
- `h1` 直下のリード文を削除
- 英語の説明文を、`Single-file Web App` を含む表現へ更新
- 英語の箇条書きを、`narrative text, tables, and images` を抽出する説明へ更新
- 日本語の説明文を、`地の文と表と画像を Markdown として抽出する Single-file Web App` という表現へ更新
- 日本語の箇条書きを、`地の文と表と画像を Markdown として抽出` する説明へ更新

## 対象ファイル
- `index.html`