### PR TITLE
docs: 名称変更とリポジトリ移転先の案内を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Mikuku's xlsx2md OGP](docs/screenshots/xlsx2md-ogp.png)
 
+> Notice
+> This app has been renamed to `miku-xlsx2md`, and the repository has moved to <https://github.com/igapyon/miku-xlsx2md>.
+> Please refer to the moved repository in principle.
+
 ## What is this?
 
 `Mikuku's xlsx2md` is a single-file web app that reads Excel (`.xlsx`) files locally and extracts prose, tables, and images as Markdown.

--- a/docs/xlsx2md-impl-spec.md
+++ b/docs/xlsx2md-impl-spec.md
@@ -1,5 +1,9 @@
 # xlsx2md Implementation Specification
 
+> Note
+> This app has been renamed to `miku-xlsx2md`, and the repository has moved to <https://github.com/igapyon/miku-xlsx2md>.
+> In principle, refer to the moved repository.
+
 ## 1. 文書の位置づけ
 
 この文書は、`xlsx2md` の現行実装が実際にどのように動作するかを整理するための実装仕様書である。

--- a/docs/xlsx2md-readme-details.md
+++ b/docs/xlsx2md-readme-details.md
@@ -1,5 +1,9 @@
 # xlsx2md README 詳細
 
+> 補足
+> このアプリは `miku-xlsx2md` に名称変更され、リポジトリは <https://github.com/igapyon/miku-xlsx2md> に移動した。
+> 原則として、参照先は移転先リポジトリとする。
+
 文書の役割は段階的に分かれています。
 
 - `README.md`

--- a/docs/xlsx2md-spec.md
+++ b/docs/xlsx2md-spec.md
@@ -1,5 +1,9 @@
 # xlsx2md 仕様
 
+> 補足
+> このアプリは `miku-xlsx2md` に名称変更され、リポジトリは <https://github.com/igapyon/miku-xlsx2md> に移動した。
+> 原則として、参照先は移転先リポジトリとする。
+
 ## 1. 文書概要
 
 `xlsx2md` は、Excel 形式の設計書ファイル (`.xlsx`) を解析し、シート単位の Markdown 文書へ変換するツールである。

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>Mikuku's xlsx2md</h1>
-    <div class="md-app-meta">Updated: 2026-04-07</div>
+    <div class="md-app-meta">Updated: 2026-04-11</div>
 
     <section class="lang-block" aria-label="English What is this">
       <h2>What is this?</h2>


### PR DESCRIPTION
## 概要

アプリが `miku-xlsx2md` に名称変更され、リポジトリが `https://github.com/igapyon/miku-xlsx2md` に移動した旨の案内を、主要な Markdown 文書の冒頭に追記します。

## 変更内容

- `README.md` に移転案内を追記
- `docs/xlsx2md-spec.md` に移転案内を追記
- `docs/xlsx2md-impl-spec.md` に移転案内を追記
- `docs/xlsx2md-readme-details.md` に移転案内を追記
- `index.html` の `Updated` 表記を `2026-04-11` に更新

## 補足

- 旧名の本文置換は行わず、移転の事実を案内する変更にとどめています。